### PR TITLE
testing building custom wolfi image with apko

### DIFF
--- a/Dockerfile.wolfi-shell-apko
+++ b/Dockerfile.wolfi-shell-apko
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+FROM docker.elastic.co/wolfi/python:3.10-dev AS builder
+
+WORKDIR /eland
+ENV VIRTUAL_ENV=/eland/venv
+RUN python -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Install
+ADD eland_import_hub_model $VIRTUAL_ENV/bin
+
+## custom image built with apko
+FROM python-bash:latest-arm64
+
+WORKDIR /eland
+ENV VIRTUAL_ENV=/eland/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY --from=builder /eland/venv /eland/venv
+
+ENTRYPOINT []

--- a/README.md
+++ b/README.md
@@ -61,3 +61,40 @@ Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
 $ docker run -it fake-eland-wolfi eland_import_hub_model --foo bar baz
 success! ['/eland/venv/bin/eland_import_hub_model', '--foo', 'bar', 'baz']
 ```
+
+## ✅ Using a custom Python Wolfi base image + bash built via apko
+
+[apko](https://github.com/chainguard-dev/apko/) is a command-line tool used to build container images, primarily based on the `apk` package format. It allows users to create minimal, efficient, and secure container base images in a reproducible way using a declarative language (YAML).
+
+**Prerequisite**
+You need `apko` to be installed locally, see https://github.com/chainguard-dev/apko/tree/main?tab=readme-ov-file#installation
+
+Build the custom base image with the minimal python image + bash
+```bash
+./apko/build.sh
+
+2024/09/06 19:35:44 INFO Determining packages for 1 architectures: [arm64]
+2024/09/06 19:35:44 INFO setting apk repositories: [https://packages.wolfi.dev/os /var/folders/v3/xk5brb8j21107_2k28qxwq8c0000gn/T/apko-temp-737571932/base_image_apkindex] arch=aarch64
+2024/09/06 19:35:45 INFO Building images for 1 architectures: [arm64]
+2024/09/06 19:35:45 INFO detected git+ssh://github.com/mgreau/testing-apko.git@4f93e6ceb2c12275b3630209a8545bf9ff1a6648 as VCS URL
+2024/09/06 19:35:45 INFO setting apk repositories: [https://packages.wolfi.dev/os /var/folders/v3/xk5brb8j21107_2k28qxwq8c0000gn/T/apko-temp-3959710311/base_image_apkindex]
+2024/09/06 19:35:45 INFO installing bash (5.2.32-r2)
+2024/09/06 19:35:45 INFO setting apk repositories: [https://packages.wolfi.dev/os]
+...
+2024/09/06 19:35:45 INFO built image layer tarball as /var/folders/v3/xk5brb8j21107_2k28qxwq8c0000gn/T/apko-temp-3959710311/apko-aarch64.tar.gz
+2024/09/06 19:35:45 INFO OCI layer digest: sha256:70e1d8630c01f496526b4c687aa55035c0fe2a5670b5e2cb7d5af39e780f26b9 arch=aarch64
+2024/09/06 19:35:45 INFO OCI layer diffID: sha256:b7636dc49d88159bdeda57954075a3d4c72714faa8ce730297979d7f9ebf5d0e arch=aarch64
+2024/09/06 19:35:45 INFO built index file as /var/folders/v3/xk5brb8j21107_2k28qxwq8c0000gn/T/apko-temp-3959710311/index.json
+Loaded image: python-bash:latest-arm64
+```
+
+The custom base image `python-bash:latest-arm64` is now available locally and can be used to build the fake-eland-wolfi image.
+
+```bash
+$ docker build -f Dockerfile.wolfi-shell-apko -t fake-eland-wolfi-apko .
+$ trivy image fake-eland-wolfi-apko
+[...]
+Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
+$ docker run -it fake-eland-wolfi-apko eland_import_hub_model --foo bar baz
+success! ['/eland/venv/bin/eland_import_hub_model', '--foo', 'bar', 'baz']
+```

--- a/apko/base_image.yaml
+++ b/apko/base_image.yaml
@@ -1,0 +1,14 @@
+contents:
+  baseimage: 
+    image: ./apko/build/base_image
+    apkindex: ./apko/build/apkindexes
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - bash
+
+archs:
+- aarch64
+

--- a/apko/build.sh
+++ b/apko/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Script for building image on top of base with apko.
+# Must be run from the root of github repository.
+
+apko_binary="${1:-apko}"
+
+WORKDIR="./apko/build"
+BASE_IMAGE=docker.elastic.co/wolfi/python:3.10
+BASE_IMAGE_WORKDIR="$WORKDIR/base_image"
+APKINDEX_WORKDIR="$WORKDIR/apkindexes"
+FS_DUMP_WORKDIR="$WORKDIR/fs_dump"
+ARCH=aarch64
+
+# Pull base image
+crane pull "$BASE_IMAGE" "$BASE_IMAGE_WORKDIR" --format=oci
+# Prepare apkindex for base image
+mkdir -p "$FS_DUMP_WORKDIR"
+crane export "$BASE_IMAGE" "$FS_DUMP_WORKDIR/fs.tar"
+tar -C "$FS_DUMP_WORKDIR" -xf "$FS_DUMP_WORKDIR/fs.tar"
+mkdir -p "$APKINDEX_WORKDIR/$ARCH/"
+cp "$FS_DUMP_WORKDIR/lib/apk/db/installed" "$APKINDEX_WORKDIR/$ARCH/APKINDEX"
+
+"$apko_binary" lock "apko/base_image.yaml"
+
+mkdir -p "$WORKDIR/top_image"
+
+"$apko_binary" build "apko/base_image.yaml" python-bash:latest "apko/python_bash.tar" --lockfile="apko/base_image.lock.json" --sbom=False
+
+docker load -i "apko/python_bash.tar"


### PR DESCRIPTION
Use `apko` to solve the problem of adding only the bash package to a minimal python3 image. 

Then it serves as a custom base image for the "eland use case".

_Note: based on https://github.com/chainguard-dev/apko/tree/main/examples/on_top_of_base_